### PR TITLE
Improved Pipelining

### DIFF
--- a/lib/work_queue.ex
+++ b/lib/work_queue.ex
@@ -9,7 +9,7 @@ defmodule WorkQueue do
 
   @doc File.read!("README.md")
 
-  def process(worker_fn, item_source, extra_opts \\ []) do
+  def process(item_source, worker_fn, extra_opts \\ []) do
     pipe_while_ok do
       package_parameters(worker_fn, item_source, extra_opts)
       |> Options.analyze

--- a/lib/work_queue/options.ex
+++ b/lib/work_queue/options.ex
@@ -12,13 +12,15 @@ defmodule WorkQueue.Options do
   
   defp default_options do
     %{
-        worker_count:             round(processing_units*0.667),
-        report_each_result_to:    fn _ -> end,
-        report_progress_to:       fn _ -> end,
-        report_progress_interval: false,
-        worker_args:              [],
-        item_source:              [],
-        get_next_item:            false
+        worker_count:                 round(processing_units*0.667),
+        report_each_result_to:        fn _ -> end,
+        report_progress_to:           fn _ -> end,
+        report_progress_interval:     false,
+        worker_args:                  [],
+        item_source:                  [],
+        get_next_item:                false,
+        update_worker_count:          fn _, _, max -> max end,
+        update_worker_count_interval: 1000
      }
   end
   
@@ -57,7 +59,15 @@ defmodule WorkQueue.Options do
 
   defp option({:worker_count, :io_bound}, result),
   do:  option({:worker_count, 10.0}, result)
+
+  defp option({:update_worker_count, func}, result)
+  when is_function(func),
+  do:  update(result, :update_worker_count, func)
   
+  defp option({:update_worker_count_interval, n}, result)
+  when is_integer(n),
+  do:  update(result, :update_worker_count_interval, n)
+
   defp option({option, value}, _result) do
     { :error, "Invalid option [ #{option}: #{inspect value} ] to #{__MODULE__}" }
   end

--- a/test/options_test.exs
+++ b/test/options_test.exs
@@ -111,4 +111,17 @@ defmodule OptionsTest do
     assert {:done, _, work=[]}         = get_next_item.(work)
     assert {:done, _, _work=[]}        = get_next_item.(work)
   end
+
+  test "can override update_worker_count function" do
+    callback = fn _ -> 10 end
+    given  = params(opts: [ update_worker_count: callback ])
+    assert {:ok, %{opts: opts}} = analyze(given, default_options)
+    assert Dict.delete(opts, :get_next_item) == default_options(update_worker_count: callback)
+  end
+  
+  test "can override update_worker_count_interval" do
+    given  = params(opts: [ update_worker_count_interval: 2000 ])
+    assert {:ok, %{opts: opts}} = analyze(given, default_options)
+    assert Dict.delete(opts, :get_next_item) == default_options(update_worker_count_interval: 2000)
+  end
 end


### PR DESCRIPTION
The natural way to use a WorkQueue is as part of a pipeline. This requires that the item source be the first argument to process, not the second. This enables, for example:

```
  1..100 
    |> WorkQueue.process( fn (val, _) -> {:ok, val*2}) )
    |> Enum.reduce(...)
```

The benefit of this is even clearer if the source is a stream or other enumerable.

I didn't really dig into the internals. I just noticed that the public API lacked that Elixir pipeline goodness (What's the Elixir equivalent of "Pythonic"?).

PS - Programming Elixir is fast becoming my most dog-eared programming book. Thanks for that!